### PR TITLE
rename 'agent' to 'contributor' to more accurately reflect its purpose 

### DIFF
--- a/HistoricalDocument.html
+++ b/HistoricalDocument.html
@@ -47,9 +47,9 @@ title: Historical and Genealogical MicroData - Historical Document
     </thead>
     <tbody class="supertype">
       <tr>
-        <th class="prop-nam" scope="row"><code>agent</code></th>
+        <th class="prop-nam" scope="row"><code>contributor</code></th>
         <td class="prop-ect"><a href="http://schema.org/Person">Person</a></td>
-        <td class="prop-desc">Person who uploaded or provided the document.</td>
+        <td class="prop-desc">Person who uploaded or provided the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>content</code></th>
@@ -58,7 +58,7 @@ title: Historical and Genealogical MicroData - Historical Document
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>creator</code></th>
-        <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a> or <a href="http://schema.org/Organization">Organization</a></td>
+        <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a> or <a href="http://schema.org/Organization">Organization</a>. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-creator">Dublin Core: creator</a>.</td>
         <td class="prop-desc">Person or organization (e.g. government agency, etc.) that created the document.</td>
       </tr>
       <tr>

--- a/HistoricalEvent.html
+++ b/HistoricalEvent.html
@@ -75,9 +75,9 @@ title: Historical and Genealogical MicroData - Historical Event
     </thead>
     <tbody class="supertype">
       <tr>
-        <th class="prop-nam" scope="row"><code>agent</code></th>
+        <th class="prop-nam" scope="row"><code>contributor</code></th>
         <td class="prop-ect"><a href="http://schema.org/Person">Person</a></td>
-        <td class="prop-desc">Person who is responsible for creating/maintaining information about the event.</td>
+        <td class="prop-desc">Person who is responsible for providing or maintaining the information about the event. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>attendees</code></th>

--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -48,9 +48,9 @@ title: Historical and Genealogical MicroData - Historical Family
     </thead>
     <tbody class="supertype">
       <tr>
-        <th class="prop-nam" scope="row"><code>agent</code></th>
+        <th class="prop-nam" scope="row"><code>contributor</code></th>
         <td class="prop-ect"><a href="http://schema.org/Person">Person</a></td>
-        <td class="prop-desc">Person responsible for providing or maintaining information about the family.</td>
+        <td class="prop-desc">Person responsible for providing or maintaining information about the family. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>adoptedChildren</code></th>

--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -70,9 +70,9 @@ title: Historical and Genealogical MicroData - Historical Person
     </thead>
     <tbody class="supertype">
       <tr>
-        <th class="prop-nam" scope="row"><code>agent</code></th>
+        <th class="prop-nam" scope="row"><code>contributor</code></th>
         <td class="prop-ect"><a href="http://schema.org/Person">Person</a></td>
-        <td class="prop-desc">Person who is responsible for providing and/or maintaining the information contained in the historical profile.</td>
+        <td class="prop-desc">Person who is responsible for providing or maintaining the information about the historical person. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>baptism</code></th>


### PR DESCRIPTION
Rename 'agent' to 'contributor' to more accurately reflect its purpose and conform to industry-standard terminology
