### PR TITLE
rename 'document' to 'source'

### DIFF
--- a/HistoricalEvent.html
+++ b/HistoricalEvent.html
@@ -85,9 +85,9 @@ title: Historical and Genealogical MicroData - Historical Event
         <td class="prop-desc">A historical person who was present the event. (Use <a href="HistoricalPerson.html">Historical Person</a> instead of <a href="http://schema.org/Person">Person</a>)</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>documents</code></th>
+        <th class="prop-nam" scope="row"><code>source</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
-        <td class="prop-desc">A historical document about or created at the event.</td>
+        <td class="prop-desc">A historical document containing information about the event.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>media</code></th>

--- a/HistoricalEvent.html
+++ b/HistoricalEvent.html
@@ -85,7 +85,7 @@ title: Historical and Genealogical MicroData - Historical Event
         <td class="prop-desc">A historical person who was present the event. (Use <a href="HistoricalPerson.html">Historical Person</a> instead of <a href="http://schema.org/Person">Person</a>)</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>source</code></th>
+        <th class="prop-nam" scope="row"><code>sources</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
         <td class="prop-desc">A historical document containing information about the event.</td>
       </tr>

--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -73,9 +73,9 @@ title: Historical and Genealogical MicroData - Historical Family
         <td class="prop-desc">Indicator of whether or not the partners are divorced.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>document</code></th>
+        <th class="prop-nam" scope="row"><code>source</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
-        <td class="prop-desc">Historical document establishing facts about the family.</td>
+        <td class="prop-desc">A historical document containing information about the family.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>partners</code></th>

--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -73,7 +73,7 @@ title: Historical and Genealogical MicroData - Historical Family
         <td class="prop-desc">Indicator of whether or not the partners are divorced.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>source</code></th>
+        <th class="prop-nam" scope="row"><code>sources</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
         <td class="prop-desc">A historical document containing information about the family.</td>
       </tr>

--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -105,9 +105,9 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">Living status of the person.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>documents</code></th>
+        <th class="prop-nam" scope="row"><code>source</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
-        <td class="prop-desc">A historical document about the person.</td>
+        <td class="prop-desc">A historical document containing information about the person.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>events</code></th>

--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -105,7 +105,7 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">Living status of the person.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>source</code></th>
+        <th class="prop-nam" scope="row"><code>sources</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
         <td class="prop-desc">A historical document containing information about the person.</td>
       </tr>


### PR DESCRIPTION
rename 'document' to 'source' to better reflect its purpose and conform to industry-established convention.
