### PR TITLE
remove the deceased flag

### DIFF
--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -100,11 +100,6 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">An event describing the details of a person's death. (Replaces <a href="http://schema.org/Person">Person</a> <code>deathDate</code>)</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>deceased</code></th>
-        <td class="prop-ect">Boolean</td>
-        <td class="prop-desc">Living status of the person.</td>
-      </tr>
-      <tr>
         <th class="prop-nam" scope="row"><code>documents</code></th>
         <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
         <td class="prop-desc">A historical document about the person.</td>


### PR DESCRIPTION
Remove the deceased flag (which can be inferred from the existence of a death event or death date) to reduce redundancy.
