### PR TITLE
normalize person events

### DIFF
--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -75,29 +75,9 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">Person who is responsible for providing and/or maintaining the information contained in the historical profile.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>baptism</code></th>
-        <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's baptism or christening.</td>
-      </tr>
-      <tr>
-        <th class="prop-nam" scope="row"><code>burial</code></th>
-        <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's burial.</td>
-      </tr>
-      <tr>
-        <th class="prop-nam" scope="row"><code>birth</code></th>
-        <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's birth. (Replaces <a href="http://schema.org/Person">Person</a> <code>birthDate</code>)</td>
-      </tr>
-      <tr>
         <th class="prop-nam" scope="row"><code>children</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>
         <td class="prop-desc">A child of the person. (Use <a href="HistoricalPerson.html">Historical Person</a> instead of <a href="http://schema.org/Person">Person</a>)</td>
-      </tr>
-      <tr>
-        <th class="prop-nam" scope="row"><code>death</code></th>
-        <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's death. (Replaces <a href="http://schema.org/Person">Person</a> <code>deathDate</code>)</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>deceased</code></th>
@@ -110,10 +90,9 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">A historical document about the person.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>events</code></th>
+        <th class="prop-nam" scope="row"><code>event</code></th>
         <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
-        <td class="prop-desc">An event describing a significant incident in the lifetime of a person. (Use in place of <a href="http://schema.org/Person">Person</a> 
-<code>homeLocation</code>, <code>jobTitle</code>, <code>memberOf</code>, <code>worksFor</code> and for other significant life events)</td>
+        <td class="prop-desc">An event in the lifetime of the person.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>parents</code></th>

--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -90,7 +90,7 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">A historical document about the person.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>event</code></th>
+        <th class="prop-nam" scope="row"><code>events</code></th>
         <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
         <td class="prop-desc">An event in the lifetime of the person.</td>
       </tr>


### PR DESCRIPTION
I propose eliminating properties such as 'baptism', 'burial', 'birth', 'death' because those events are redundant because they can be expressed by the 'events' property.
