### PR TITLE
clarify document references model

### DIFF
--- a/HistoricalDocument.html
+++ b/HistoricalDocument.html
@@ -67,11 +67,6 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Date the document was created.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>event</code></th>
-        <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
-        <td class="prop-desc">Historical event at which or in relation to which the document was created.</td>
-      </tr>
-      <tr>
         <th class="prop-nam" scope="row"><code>inLanguage</code></th>
         <td class="prop-ect">Text</td>
         <td class="prop-desc">The language of the content. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
@@ -82,9 +77,9 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Location where the content was created.</td>
       </tr>      
       <tr>
-        <th class="prop-nam" scope="row"><code>mentioned</code></th>
-        <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>
-        <td class="prop-desc">Person who is mentioned in the document.</td>
+        <th class="prop-nam" scope="row"><code>references</code></th>
+        <td class="prop-ect"><a href="http://schema.org/Thing">Thing</a></td>
+        <td class="prop-desc">Something that is referenced by this document, such as a <a href="HistoricalPerson.html">Historical Person</a> or <a href="HistoricalEvent.html">Historical Event</a>. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-references">Dublin Core: references</a>.</td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>note</code></th>

--- a/HistoricalDocument.html
+++ b/HistoricalDocument.html
@@ -77,9 +77,19 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Location where the content was created.</td>
       </tr>      
       <tr>
-        <th class="prop-nam" scope="row"><code>references</code></th>
-        <td class="prop-ect"><a href="http://schema.org/Thing">Thing</a></td>
-        <td class="prop-desc">Something that is referenced by this document, such as a <a href="HistoricalPerson.html">Historical Person</a> or <a href="HistoricalEvent.html">Historical Event</a>. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-references">Dublin Core: references</a>.</td>
+        <th class="prop-nam" scope="row"><code>persons</code></th>
+        <td class="prop-ect"><a href="http://schema.org/Person">Person</a> (including <a href="HistoricalPerson.html">HistoricalPerson</a>).</td>
+        <td class="prop-desc">Persons that are described or referenced by this document. </td>
+      </tr>      
+      <tr>
+        <th class="prop-nam" scope="row"><code>events</code></th>
+        <td class="prop-ect"><a href="http://schema.org/Event">Event</a> (including <a href="HistoricalEvent.html">HistoricalEvent</a>).</td>
+        <td class="prop-desc">Events that are described or referenced by this document. </td>
+      </tr>      
+      <tr>
+        <th class="prop-nam" scope="row"><code>families</code></th>
+        <td class="prop-ect"><a href="HistoricalFamily.html">HistoricalFamily</a>.</td>
+        <td class="prop-desc">Families that are described or referenced by this document.</td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>note</code></th>


### PR DESCRIPTION
This pull request renames historical document 'mentioned' to 'references' and expands its range to 'Thing' to clarify the meaning of the property. It also removes 'events' from historical document to eliminate the redundancy.
