### PR TITLE
clarify document content metadata model

### DIFF
--- a/HistoricalDocument.html
+++ b/HistoricalDocument.html
@@ -62,9 +62,9 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Person or organization (e.g. government agency, etc.) that created the document.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>temporal</code></th>
+        <th class="prop-nam" scope="row"><code>dates</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">The temporal "coverage" of the document, i.e. the date(s) and time periods that are referenced by the content of the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-temporal">Dublin Core: temporal</a></td>
+        <td class="prop-desc">The date(s) and time periods that are referenced by the <em>content</em> of the document. This property is described by Dublin Core as <a href="http://dublincore.org/documents/dcmi-terms/#terms-temporal">"temporal coverage".</a></td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>event</code></th>
@@ -77,9 +77,9 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">The language of the content of the document. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
       </tr>      
       <tr>
-        <th class="prop-nam" scope="row"><code>spatial</code></th>
+        <th class="prop-nam" scope="row"><code>locations</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">The spatial "coverage" of the document, i.e. the place(s) and locations that are referenced by the content of the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-spatial">Dublin Core: spatial</a></td>
+        <td class="prop-desc">The place(s) and locations that are referenced by the <em>content</em> of the document. This property is described by Dublin Core as <a href="http://dublincore.org/documents/dcmi-terms/#terms-spatial">"spatial coverage".</a></td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>mentioned</code></th>

--- a/HistoricalDocument.html
+++ b/HistoricalDocument.html
@@ -62,9 +62,9 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Person or organization (e.g. government agency, etc.) that created the document.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>documentDate</code></th>
+        <th class="prop-nam" scope="row"><code>temporal</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">Date the document was created.</td>
+        <td class="prop-desc">The temporal "coverage" of the document, i.e. the date(s) and time periods that are referenced by the content of the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-temporal">Dublin Core: temporal</a></td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>event</code></th>
@@ -72,15 +72,15 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Historical event at which or in relation to which the document was created.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>inLanguage</code></th>
+        <th class="prop-nam" scope="row"><code>language</code></th>
         <td class="prop-ect">Text</td>
-        <td class="prop-desc">The language of the content. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
+        <td class="prop-desc">The language of the content of the document. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
       </tr>      
       <tr>
-        <th class="prop-nam" scope="row"><code>location</code></th>
-        <td class="prop-ect"><a href="http://schema.org/Place">Place</a></td>
-        <td class="prop-desc">Location where the content was created.</td>
-      </tr>      
+        <th class="prop-nam" scope="row"><code>spatial</code></th>
+        <td class="prop-ect">Date</td>
+        <td class="prop-desc">The spatial "coverage" of the document, i.e. the place(s) and locations that are referenced by the content of the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-spatial">Dublin Core: spatial</a></td>
+      </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>mentioned</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>


### PR DESCRIPTION
renaming 'documentDate' to 'temporal' and 'location' to 'spatial' to clarify the meaning of those properties as describing the nature of the content of the document. renaming 'inLanguage' to 'language' to conform to convention for describing the nature of the content of the document
