### PR TITLE
rename baptism to christening

### DIFF
--- a/HistoricalDocument.html
+++ b/HistoricalDocument.html
@@ -62,9 +62,9 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Person or organization (e.g. government agency, etc.) that created the document.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>documentDate</code></th>
+        <th class="prop-nam" scope="row"><code>temporal</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">Date the document was created.</td>
+        <td class="prop-desc">The temporal "coverage" of the document, i.e. the date(s) and time periods that are referenced by the content of the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-temporal">Dublin Core: temporal</a></td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>event</code></th>
@@ -72,15 +72,15 @@ title: Historical and Genealogical MicroData - Historical Document
         <td class="prop-desc">Historical event at which or in relation to which the document was created.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>inLanguage</code></th>
+        <th class="prop-nam" scope="row"><code>language</code></th>
         <td class="prop-ect">Text</td>
-        <td class="prop-desc">The language of the content. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
+        <td class="prop-desc">The language of the content of the document. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
       </tr>      
       <tr>
-        <th class="prop-nam" scope="row"><code>location</code></th>
-        <td class="prop-ect"><a href="http://schema.org/Place">Place</a></td>
-        <td class="prop-desc">Location where the content was created.</td>
-      </tr>      
+        <th class="prop-nam" scope="row"><code>spatial</code></th>
+        <td class="prop-ect">Date</td>
+        <td class="prop-desc">The spatial "coverage" of the document, i.e. the place(s) and locations that are referenced by the content of the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-spatial">Dublin Core: spatial</a></td>
+      </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>mentioned</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>

--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -75,7 +75,7 @@ title: Historical and Genealogical MicroData - Historical Person
         <td class="prop-desc">Person who is responsible for providing and/or maintaining the information contained in the historical profile.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>baptism</code></th>
+        <th class="prop-nam" scope="row"><code>christening</code></th>
         <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
         <td class="prop-desc">An event describing the details of a person's baptism or christening.</td>
       </tr>


### PR DESCRIPTION
since we've decided to keep around "canonical" properties for most-used events, I propose renaming `baptism` to `christening` to allow for a more generic usage of the property. I think, generally speaking, genealogists are more comfortable using `christening` to include baptism et. al. as opposed to using `baptism` to include christening et. al.
