### PR TITLE
Remove the 'adoptedChildren' property for clarity and normalization

### DIFF
--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -53,11 +53,6 @@ title: Historical and Genealogical MicroData - Historical Family
         <td class="prop-desc">Person responsible for providing or maintaining information about the family. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>adoptedChildren</code></th>
-        <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>
-        <td class="prop-desc">Historical person with the role of child in the family who was not born to the parents of the family</td>
-      </tr>
-      <tr>
         <th class="prop-nam" scope="row"><code>children</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>
         <td class="prop-desc">Historical person with the role of child in the family.</td>

--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -53,6 +53,11 @@ title: Historical and Genealogical MicroData - Historical Family
         <td class="prop-desc">Person responsible for providing or maintaining information about the family. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
+        <th class="prop-nam" scope="row"><code>adoptions</code></th>
+        <td class="prop-ect"><a href="HistoricalEvent.html">Historical Event</a></td>
+        <td class="prop-desc">Historical events describing the adoptions in the family.</td>
+      </tr>
+      <tr>
         <th class="prop-nam" scope="row"><code>children</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>
         <td class="prop-desc">Historical person with the role of child in the family.</td>


### PR DESCRIPTION
I propose we remove the `adoptedChildren` property so we don't make people have to make difficult and confusing decisions about how to separate the children of a family into separate bags.
