### PR TITLE
rename 'partner' to 'parent'

### DIFF
--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -78,7 +78,7 @@ title: Historical and Genealogical MicroData - Historical Family
         <td class="prop-desc">A historical document containing information about the family.</td>
       </tr>
       <tr>
-        <th class="prop-nam" scope="row"><code>partners</code></th>
+        <th class="prop-nam" scope="row"><code>parents</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a></td>
         <td class="prop-desc">Historical person with the role of parent/partner in the family.</td>
       </tr>


### PR DESCRIPTION
I propose we rename 'partner' to 'parent' for consistency with the `parents` property on person and for consistency in industry.
