### PR TITLE
rename 'document' to 'record'

### DIFF
--- a/HistoricalEvent.html
+++ b/HistoricalEvent.html
@@ -104,8 +104,8 @@ title: Historical and Genealogical MicroData - Historical Event
       <tr>
       <tr>
         <th class="prop-nam" scope="row"><code>sources</code></th>
-        <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
-        <td class="prop-desc">A historical document containing information about the event.</td>
+        <td class="prop-ect"><a href="HistoricalRecord.html">Historical Record</a></td>
+        <td class="prop-desc">A historical record containing information about the event.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>media</code></th>

--- a/HistoricalFamily.html
+++ b/HistoricalFamily.html
@@ -74,8 +74,8 @@ title: Historical and Genealogical MicroData - Historical Family
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>sources</code></th>
-        <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
-        <td class="prop-desc">A historical document containing information about the family.</td>
+        <td class="prop-ect"><a href="HistoricalRecord.html">Historical Record</a></td>
+        <td class="prop-desc">A historical record containing information about the family.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>partners</code></th>

--- a/HistoricalPerson.html
+++ b/HistoricalPerson.html
@@ -118,8 +118,8 @@ title: Historical and Genealogical MicroData - Historical Person
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>sources</code></th>
-        <td class="prop-ect"><a href="HistoricalDocument.html">Historical Document</a></td>
-        <td class="prop-desc">A historical document containing information about the person.</td>
+        <td class="prop-ect"><a href="HistoricalRecord.html">Historical Record</a></td>
+        <td class="prop-desc">A historical record containing information about the person.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>events</code></th>

--- a/HistoricalRecord.html
+++ b/HistoricalRecord.html
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Historical and Genealogical MicroData - Historical Document
+title: Historical and Genealogical MicroData - Historical Record
 ---
 
 <div id="main" role="main">
-  <h1 class="page-title"><a href="http://schema.org/Thing">Thing</a>  &gt; <a href="HistoricalDocument.html">Historical Document</a></h1>
+  <h1 class="page-title"><a href="http://schema.org/Thing">Thing</a>  &gt; <a href="HistoricalRecord.html">Historical Record</a></h1>
   <table cellspacing="3" class="definition-table">
     <thead>
       <tr>
@@ -42,70 +42,70 @@ title: Historical and Genealogical MicroData - Historical Document
     </tbody>
     <thead class="supertype">
       <tr>
-        <th class="supertype-name" colspan="3">Properties from <a href="HistoricalDocument.html">Historical Document</a></th>
+        <th class="supertype-name" colspan="3">Properties from <a href="HistoricalRecord.html">Historical Record</a></th>
       </tr>
     </thead>
     <tbody class="supertype">
       <tr>
         <th class="prop-nam" scope="row"><code>contributor</code></th>
         <td class="prop-ect"><a href="http://schema.org/Person">Person</a></td>
-        <td class="prop-desc">Person who uploaded or provided the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
+        <td class="prop-desc">Person who uploaded or provided the record. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-contributor">Dublin Core: contributor</a>.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>content</code></th>
         <td class="prop-ect">Text</td>
-        <td class="prop-desc">Text content of the document.</td>
+        <td class="prop-desc">Text content of the record.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>creator</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">Historical Person</a> or <a href="http://schema.org/Organization">Organization</a>.</td>
-        <td class="prop-desc">Person or organization (e.g. government agency, etc.) that created the document. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-creator">Dublin Core: creator</a>.</td>
+        <td class="prop-desc">Person or organization (e.g. government agency, etc.) that created the record. See also <a href="http://dublincore.org/documents/dcmi-terms/#terms-creator">Dublin Core: creator</a>.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>dates</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">The date(s) and time periods that are referenced by the <em>content</em> of the document. This property is described by Dublin Core as <a href="http://dublincore.org/documents/dcmi-terms/#terms-temporal">"temporal coverage".</a></td>
+        <td class="prop-desc">The date(s) and time periods that are referenced by the <em>content</em> of the record. This property is described by Dublin Core as <a href="http://dublincore.org/documents/dcmi-terms/#terms-temporal">"temporal coverage".</a></td>
       </tr>
       <tr>
       <tr>
         <th class="prop-nam" scope="row"><code>language</code></th>
         <td class="prop-ect">Text</td>
-        <td class="prop-desc">The language of the content of the document. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
+        <td class="prop-desc">The language of the content of the record. Please use of of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>.</td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>locations</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">The place(s) and locations that are referenced by the <em>content</em> of the document. This property is described by Dublin Core as <a href="http://dublincore.org/documents/dcmi-terms/#terms-spatial">"spatial coverage".</a></td>
+        <td class="prop-desc">The place(s) and locations that are referenced by the <em>content</em> of the record. This property is described by Dublin Core as <a href="http://dublincore.org/documents/dcmi-terms/#terms-spatial">"spatial coverage".</a></td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>persons</code></th>
         <td class="prop-ect"><a href="HistoricalPerson.html">HistoricalPerson</a></td>
-        <td class="prop-desc">Persons that are described or referenced by this document.</td>
+        <td class="prop-desc">Persons that are described or referenced by this record.</td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>events</code></th>
         <td class="prop-ect"><a href="HistoricalEvent.html">HistoricalEvent</a></td>
-        <td class="prop-desc">Events that are described or referenced by this document. </td>
+        <td class="prop-desc">Events that are described or referenced by this record. </td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>families</code></th>
         <td class="prop-ect"><a href="HistoricalFamily.html">HistoricalFamily</a>.</td>
-        <td class="prop-desc">Families that are described or referenced by this document.</td>
+        <td class="prop-desc">Families that are described or referenced by this record.</td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>note</code></th>
         <td class="prop-ect">Text</td>
-        <td class="prop-desc">Note or comment related to the document.</td>
+        <td class="prop-desc">Note or comment related to the record.</td>
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>modifiedDate</code></th>
         <td class="prop-ect">Date</td>
-        <td class="prop-desc">Date of the most recent revision to the information about document.</td>
+        <td class="prop-desc">Date of the most recent revision to the information about record.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>type</code></th>
         <td class="prop-ect">Text</td>
-        <td class="prop-desc">Type of document.</td>
+        <td class="prop-desc">Type of record.</td>
       </tr>      
     </tbody>
   </table>


### PR DESCRIPTION
I propose we rename 'document' to 'record' to conform to common convention, industry standard, and to more accurately reflect its generic use.
