### PR TITLE
Rename files to use .html

### DIFF
--- a/Event.html
+++ b/Event.html
@@ -27,7 +27,7 @@ title: Historical and Genealogical MicroData - Event
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>source</code></th>
-        <td class="prop-ect"><a href="HistoricalRecord">HistoricalRecord</a></td>
+        <td class="prop-ect"><a href="HistoricalRecord.html">HistoricalRecord</a></td>
         <td class="prop-desc">The source(s) of the information on the event.</td>
       </tr>
       <tr>

--- a/Family.html
+++ b/Family.html
@@ -4,7 +4,7 @@ title: Historical and Genealogical MicroData - Family
 ---
 
 <div id="main" role="main">
-  <h1 class="page-title"><a href="http://schema.org/Thing">Thing</a> &gt; <a href="Family">Family</a></h1>
+  <h1 class="page-title"><a href="http://schema.org/Thing">Thing</a> &gt; <a href="Family.html">Family</a></h1>
   A historical or genealogical nuclear family
   <table cellspacing="3" class="definition-table">
     <thead>
@@ -43,7 +43,7 @@ title: Historical and Genealogical MicroData - Family
     </tbody>
     <thead class="supertype">
       <tr>
-        <th class="supertype-name" colspan="3">Properties from <a href="Family">Family</a></th>
+        <th class="supertype-name" colspan="3">Properties from <a href="Family.html">Family</a></th>
       </tr>
     </thead>
     <tbody class="supertype">
@@ -79,7 +79,7 @@ title: Historical and Genealogical MicroData - Family
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>source</code></th>
-        <td class="prop-ect"><a href="HistoricalRecord">HistoricalRecord</a></td>
+        <td class="prop-ect"><a href="HistoricalRecord.html">HistoricalRecord</a></td>
         <td class="prop-desc">The source(s) of the information on the family.</td>
       </tr>
     </tbody>

--- a/HistoricalRecord.html
+++ b/HistoricalRecord.html
@@ -4,7 +4,7 @@ title: Historical and Genealogical MicroData - HistoricalRecord
 ---
 
 <div id="main" role="main">
-  <h1 class="page-title"><a href="http://schema.org/Thing">Thing</a> &gt; <a href="http://schema.org/CreativeWork">CreativeWork</a> &gt; <a href="HistoricalRecord">HistoricalRecord</a></h1>
+  <h1 class="page-title"><a href="http://schema.org/Thing">Thing</a> &gt; <a href="http://schema.org/CreativeWork">CreativeWork</a> &gt; <a href="HistoricalRecord.html">HistoricalRecord</a></h1>
   <table cellspacing="3" class="definition-table">
     <thead>
       <tr>
@@ -249,7 +249,7 @@ title: Historical and Genealogical MicroData - HistoricalRecord
     </tbody>
     <thead class="supertype">
       <tr>
-        <th class="supertype-name" colspan="3">Properties from <a href="HistoricalRecord">HistoricalRecord</a></th>
+        <th class="supertype-name" colspan="3">Properties from <a href="HistoricalRecord.html">HistoricalRecord</a></th>
       </tr>
     </thead>
     <tbody class="supertype">
@@ -270,7 +270,7 @@ title: Historical and Genealogical MicroData - HistoricalRecord
       </tr>      
       <tr>
         <th class="prop-nam" scope="row"><code>family</code></th>
-        <td class="prop-ect"><a href="Family">Family</a></td>
+        <td class="prop-ect"><a href="Family.html">Family</a></td>
         <td class="prop-desc">Family(ies) that are described or referenced by this record.</td>
       </tr>      
       <tr>	

--- a/Person.html
+++ b/Person.html
@@ -58,7 +58,7 @@ title: Historical and Genealogical MicroData - Person
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>source</code></th>
-        <td class="prop-ect"><a href="HistoricalRecord">HistoricalRecord</a></td>
+        <td class="prop-ect"><a href="HistoricalRecord.html">HistoricalRecord</a></td>
         <td class="prop-desc">The source(s) of the information on the person.</td>
       </tr>
     </tbody>

--- a/schemas.html
+++ b/schemas.html
@@ -12,10 +12,10 @@ title: Historical and Genealogical MicroData - Schemas
 <p>Historical and genealogical schemas:</p>
 
 <ul>
-  <li><a href="HistoricalRecord">HistoricalRecord</a></li>
-  <li><a href="Event">Event</a> enhancements</li>
-  <li><a href="Family">Family</a></li>
-  <li><a href="Person">Person</a> enhancements</li>
+  <li><a href="HistoricalRecord.html">HistoricalRecord</a></li>
+  <li><a href="Event.html">Event</a> enhancements</li>
+  <li><a href="Family.html">Family</a></li>
+  <li><a href="Person.html">Person</a> enhancements</li>
 </ul>
 
 <p>Please see <a href="http://schema.org">schema.org</a> for more information about the general data types and properties.</p>


### PR DESCRIPTION
Apparently Github doesn't render html files unless they end with .html. This Pull Request simply renames all the files to use .html and fixes up the links.
