### PR TITLE
Remove christening and burial

### DIFF
--- a/Person.html
+++ b/Person.html
@@ -23,22 +23,12 @@ title: Historical and Genealogical MicroData - Person
       <tr>
         <th class="prop-nam" scope="row"><code>birth</code></th>
         <td class="prop-ect"><a href="http://schema.org/Event">Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's birth. (Replaces or enhances <a href="http://schema.org/Person">Person</a> <code>birthDate</code>.)</td>
-      </tr>
-      <tr>
-        <th class="prop-nam" scope="row"><code>burial</code></th>
-        <td class="prop-ect"><a href="http://schema.org/Event">Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's burial.</td>
-      </tr>
-      <tr>
-        <th class="prop-nam" scope="row"><code>christening</code></th>
-        <td class="prop-ect"><a href="http://schema.org/Event">Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's baptism or christening.</td>
+        <td class="prop-desc">An event describing the details of a person's birth or birth-like event such as christening.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>death</code></th>
         <td class="prop-ect"><a href="http://schema.org/Event">Event</a></td>
-        <td class="prop-desc">An event describing the details of a person's death. (Replaces or enhances <a href="http://schema.org/Person">Person</a> <code>deathDate</code>)</td>
+        <td class="prop-desc">An event describing the details of a person's death or death-like event such as burial.</td>
       </tr>
       <tr>
         <th class="prop-nam" scope="row"><code>event</code></th>


### PR DESCRIPTION
As discussed, christening and burial information can be captured in the 'birth', 'death', or 'event' fields so a separate entry for them is not needed.
